### PR TITLE
Three more patches

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -146,17 +146,17 @@ namespace {
 
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn
   constexpr Score PassedRank[RANK_NB] = {
-    S(0, 0), S(5, 7), S(5, 13), S(32, 42), S(70, 70), S(172, 170), S(217, 269)
+    S(0, 0), S(5, 7), S(5, 13), S(18, 23), S(74, 58), S(164, 166), S(268, 243)
   };
 
   // PassedFile[File] contains a bonus according to the file of a passed pawn
   constexpr Score PassedFile[FILE_NB] = {
-    S(  9, 10), S(2, 10), S(1, -8), S(-20,-12),
-    S(-20,-12), S(1, -8), S(2, 10), S(  9, 10)
+    S( 15,  7), S(-5, 14), S( 1, -5), S(-22,-11),
+    S(-22,-11), S( 1, -5), S(-5, 14), S( 15,  7)
   };
 
   // PassedDanger[Rank] contains a term to weight the passed score
-  constexpr int PassedDanger[RANK_NB] = { 0, 0, 0, 2, 7, 12, 19 };
+  constexpr int PassedDanger[RANK_NB] = { 0, 0, 0, 3, 6, 12, 21 };
 
   // KingProtector[PieceType-2] contains a penalty according to distance from king
   constexpr Score KingProtector[] = { S(3, 5), S(4, 3), S(3, 0), S(1, -1) };

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -32,42 +32,42 @@ namespace {
   #define S(mg, eg) make_score(mg, eg)
 
   // Isolated pawn penalty
-  constexpr Score Isolated = S(13, 18);
+  constexpr Score Isolated = S(13, 16);
 
   // Backward pawn penalty
-  constexpr Score Backward = S(24, 12);
+  constexpr Score Backward = S(17, 11);
 
   // Connected pawn bonus by opposed, phalanx, #support and rank
   Score Connected[2][2][3][RANK_NB];
 
   // Doubled pawn penalty
-  constexpr Score Doubled = S(18, 38);
+  constexpr Score Doubled = S(13, 40);
 
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V( -9), V(64), V(77), V( 44), V( 4), V( -1), V(-11) },
-    { V(-15), V(83), V(51), V(-10), V( 1), V(-10), V(-28) },
-    { V(-18), V(84), V(27), V(-12), V(21), V( -7), V(-36) },
-    { V( 12), V(79), V(25), V( 19), V( 9), V( -6), V(-33) }
+    { V( 7), V(76), V(84), V( 38), V( 7), V( 30), V(-19) },
+    { V(-3), V(93), V(52), V(-17), V(12), V(-22), V(-35) },
+    { V(-6), V(83), V(25), V(-24), V(15), V( 22), V(-39) },
+    { V(11), V(83), V(19), V(  8), V(18), V(-21), V(-30) }
   };
 
   // Danger of enemy pawns moving toward our king by [type][distance from edge][rank].
   // For the unopposed and unblocked cases, RANK_1 = 0 is used when opponent has
   // no pawn on the given file, or their pawn is behind our king.
   constexpr Value StormDanger[][4][RANK_NB] = {
-    { { V( 4),  V(  73), V( 132), V(46), V(31) },  // Unopposed
-      { V( 1),  V(  64), V( 143), V(26), V(13) },
-      { V( 1),  V(  47), V( 110), V(44), V(24) },
-      { V( 0),  V(  72), V( 127), V(50), V(31) } },
-    { { V( 0),  V(   0), V(  19), V(23), V( 1) },  // BlockedByPawn
-      { V( 0),  V(   0), V(  88), V(27), V( 2) },
-      { V( 0),  V(   0), V( 101), V(16), V( 1) },
-      { V( 0),  V(   0), V( 111), V(22), V(15) } },
-    { { V(22),  V(  45), V( 104), V(62), V( 6) },  // Unblocked
-      { V(31),  V(  30), V(  99), V(39), V(19) },
-      { V(23),  V(  29), V(  96), V(41), V(15) },
-      { V(21),  V(  23), V( 116), V(41), V(15) } }
+    { { V(11),  V( 79), V(132), V( 68), V( 33) },  // Unopposed
+      { V( 4),  V(104), V(155), V(  4), V( 21) },
+      { V(-7),  V( 59), V(142), V( 45), V( 30) },
+      { V( 0),  V( 62), V(113), V( 43), V( 13) } },
+    { { V( 0),  V(  0), V( 37), V(  5), V(-48) },  // BlockedByPawn
+      { V( 0),  V(  0), V( 68), V(-12), V( 13) },
+      { V( 0),  V(  0), V(111), V(-25), V( -3) },
+      { V( 0),  V(  0), V(108), V( 14), V( 21) } },
+    { { V(38),  V( 78), V( 83), V( 35), V( 22) },  // Unblocked
+      { V(33),  V(-15), V(108), V( 12), V( 28) },
+      { V( 8),  V( 25), V( 94), V( 68), V( 25) },
+      { V( 6),  V( 48), V(120), V( 68), V( 40) } }
   };
 
   #undef S

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -737,6 +737,7 @@ namespace {
     // Step 9. Null move search with verification search (~40 Elo)
     if (   !PvNode
         && (ss-1)->currentMove != MOVE_NULL
+        && (ss-1)->statScore < 30000
         &&  eval >= beta
         &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
         && (ss->ply >= thisThread->nmp_ply || ss->ply % 2 != thisThread->nmp_odd))


### PR DESCRIPTION
@Stefan Geschwentner and @snicolet: Tweak null move pruning conditions.
@vondele and @snicolet: Remove goto, limit skipping to NMP
@candirufish and @snicolet: Tuned some pawns and evaluation constants

- [ ] de08896
- [ ] 4d64742
- [ ] fc0a1f3

- [x] A pull request for every patch will open soon. (If I can)