### PR TITLE
Remove goto, limit skipping to NMP

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -713,9 +713,6 @@ namespace {
     improving =   ss->staticEval >= (ss-2)->staticEval
                ||(ss-2)->staticEval == VALUE_NONE;
 
-    if (ss->excludedMove || !pos.non_pawn_material(pos.side_to_move()))
-        goto moves_loop;
-
     // Step 7. Razoring (skipped when in check, ~2 Elo)
     if (  !PvNode
         && depth < 3 * ONE_PLY
@@ -739,6 +736,8 @@ namespace {
         && (ss-1)->currentMove != MOVE_NULL
         &&  eval >= beta
         &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
+        && !ss->excludedMove
+        &&  pos.non_pawn_material(pos.side_to_move())
         && (ss->ply >= thisThread->nmp_ply || ss->ply % 2 != thisThread->nmp_odd))
     {
         assert(eval - beta >= 0);


### PR DESCRIPTION
passed STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 32035 W: 6523 L: 6422 D: 19090
http://tests.stockfishchess.org/tests/view/5af142ca0ebc597fb3d39bb6

passed LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 41431 W: 6187 L: 6097 D: 29147
http://tests.stockfishchess.org/tests/view/5af148770ebc597fb3d39bc1

Bench: 4448588

@vondele's patch