### PR TITLE
Do null move pruning only if last stat score < 30000. bench 5088156

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -737,6 +737,7 @@ namespace {
     // Step 9. Null move search with verification search (~40 Elo)
     if (   !PvNode
         && (ss-1)->currentMove != MOVE_NULL
+        && (ss-1)->statScore < 30000
         &&  eval >= beta
         &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
         && (ss->ply >= thisThread->nmp_ply || ss->ply % 2 != thisThread->nmp_odd))


### PR DESCRIPTION
Allow null move pruning only if last stat score < 30000.

Passed STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 12653 W: 2641 L: 2454 D: 7558
http://tests.stockfishchess.org/tests/view/5af1d8830ebc5968e6523edb

Passed LTC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 19782 W: 3072 L: 2878 D: 13832
http://tests.stockfishchess.org/tests/view/5af1ee8c0ebc5968e6523ee4

Ideas for further work:

• Tune the stat score threshold.
• Try depth based stat score threshold.
• Try stat score condition for other prunings.

Bench: 5088156

@locutus2's patch